### PR TITLE
添加lore物品清理选项

### DIFF
--- a/src/main/kotlin/clean/drop.kt
+++ b/src/main/kotlin/clean/drop.kt
@@ -15,6 +15,7 @@ import top.e404.eplugin.EPlugin.Companion.placeholder
 private inline val dropCfg get() = Config.config.drop
 private inline val trashcanCfg get() = Config.config.trashcan
 
+
 /**
  * 最近一次清理掉落物的数量
  */
@@ -84,6 +85,10 @@ fun World.cleanDrop(): Pair<Int, Int> {
     if (dropCfg.writtenBook) waitingForClean.removeIf {
         it.itemStack.type == Material.WRITABLE_BOOK
                 && (it.itemStack.itemMeta as? BookMeta)?.hasPages() == true
+    }
+    // dropCfg.lore == true 时不清理lore的物品(从列表中移除)
+    if (dropCfg.lore) waitingForClean.removeIf {
+        it.itemStack.itemMeta?.hasLore() == true
     }
 
     val items = mutableMapOf<String, MutableList<Item>>()

--- a/src/main/kotlin/config/Config.kt
+++ b/src/main/kotlin/config/Config.kt
@@ -52,6 +52,7 @@ data class DropConfig(
     @SerialName("is_black")
     var black: Boolean = true,
     var enchant: Boolean = false,
+    var lore: Boolean = false,
     @SerialName("written_book")
     var writtenBook: Boolean = false,
     var match: MutableList<@Serializable(RegexSerialization::class) Regex> = mutableListOf(),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,9 +76,14 @@ drop:
   # 若设置为false则清理带附魔的物品
   enchant: false
 
+  # 若设置为true则不清理带描述的物品
+  # 若设置为false则清理带描述的物品
+  lore: false
+
   # 若设置为true则不清理写过的书
   # 若设置为false则清理写过的书 (match规则匹配时才会清理)
   written_book: false
+
 
   # 掉落物类型(支持正则)
   # https://hub.spigotmc.org/javadocs/spigot/org/bukkit/material/package-summary.html


### PR DESCRIPTION
添加了对含有lore物品的过滤功能，用于防止特殊物品（如：qs商店展示）被清理。