### PR TITLE
新增世界白名单和必定删除列表

### DIFF
--- a/src/main/kotlin/clean/chunk.kt
+++ b/src/main/kotlin/clean/chunk.kt
@@ -28,7 +28,16 @@ fun cleanDenseEntities() {
         PL.debug { "密集实体清理已禁用" }
         return
     }
-    val worlds = Bukkit.getWorlds().filterNot { chunkCfg.disableWorld.contains(it.name) }
+
+    val worlds: List<World>
+    if (chunkCfg.worldBlack) {
+        PL.debug { "清理世界已开启黑名单" }
+        worlds = Bukkit.getWorlds().filter { chunkCfg.disableWorld.contains(it.name) }
+    } else {
+        PL.debug { "清理世界已开启白名单" }
+        worlds = Bukkit.getWorlds().filterNot { chunkCfg.disableWorld.contains(it.name) }
+    }
+
     PL.debug { "开始进行密集实体检查" }
     PL.debug {
         buildString {

--- a/src/main/kotlin/config/Config.kt
+++ b/src/main/kotlin/config/Config.kt
@@ -61,6 +61,7 @@ data class DropConfig(
 @Serializable
 data class LivingConfig(
     var enable: Boolean = true,
+    var worldBlack: Boolean = false,
     @SerialName("disable_world")
     var disableWorld: MutableList<String> = mutableListOf(),
     var finish: String = "",
@@ -68,6 +69,8 @@ data class LivingConfig(
     @SerialName("is_black")
     var black: Boolean = true,
     var match: MutableList<@Serializable(RegexSerialization::class) Regex> = mutableListOf(),
+    @SerialName("whiteKey")
+    var whiteKey: MutableList<String> = mutableListOf(),
 )
 
 @Serializable
@@ -80,6 +83,7 @@ data class Settings(
 @Serializable
 data class ChunkConfig(
     var enable: Boolean = true,
+    var worldBlack: Boolean = false,
     @SerialName("disable_world")
     var disableWorld: MutableList<String> = mutableListOf(),
     var finish: String = "",

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,10 @@ living:
   # 设置为true以启用
   enable: true
 
+  # 若设置为true则按黑名单匹配(名字匹配的才清理)
+  # 若设置为false则按白名单匹配(名字匹配的不清理)
+  worldBlack: true
+
   # 禁用的世界(不支持正则)
   disable_world:
     - "不清理的世界"
@@ -55,6 +59,10 @@ living:
     - "(GLOW_)?SQUID"
     - "PHANTOM"
     - "PILLAGER"
+
+  # 必定删除的生物名关键词
+  whiteKey:
+    - 'BOSS'
 
 # 清理掉落物
 drop:
@@ -106,7 +114,11 @@ chunk:
   # 设置为true以启用
   enable: true
 
-  # 禁用的世界(不支持正则)
+  # 若设置为true则按黑名单匹配(名字匹配的才清理)
+  # 若设置为false则按白名单匹配(名字匹配的不清理)
+  worldBlack: true
+
+  # 禁用/开启的世界(不支持正则)
   disable_world:
     - "不清理的世界"
 


### PR DESCRIPTION
新增living和chunk内的世界白名单的worldBlack选项
新增living中为趣味生存制作的检测名称关键词必定删除的whiteKey列表

新增选项已经过本地多次测试，无明显问题

大哥的框架功能很丰富，但我纯小白通宵构建了五个小时才构建成功
（大哥grade脚本错误的地方很多，自己修了好久呜呜呜）